### PR TITLE
Fix prep_dat and make_res to work on R3.6.3

### DIFF
--- a/R/get_veda_dat.R
+++ b/R/get_veda_dat.R
@@ -230,9 +230,12 @@ prep_sector_dat <- function(sector_dat){
 
   sector_dat %>%
     #strings to lower
-    dplyr::mutate_if(is.character, stringr::str_to_lower) %>%
-    #column names to lower
-    dplyr::rename_with(tolower)
+    dplyr::mutate_if(is.character, stringr::str_to_lower)
+
+  #column names to lower
+  names(sector_dat) <- stringr::str_to_lower(names(sector_dat))
+
+  sector_dat
 
 
 

--- a/R/make_res.R
+++ b/R/make_res.R
@@ -236,7 +236,9 @@ out <- dat %>%
     dplyr::select(!!flow_col, !!node_col, attribute) %>%
     tidyr::pivot_wider(values_from = !!node_col,
                        names_from = attribute,
-                       values_fn = list) %>%
+                       #specify that non-unique values are collapsed to a list
+                       #for all variables
+                       values_fn = list(list)) %>%
     dplyr::group_by(!!flow_col) %>%
     summarise(edges = map(.x = var_fout,
                          .y = var_fin,


### PR DESCRIPTION
make_res: make_edges() call to pivot_wider needed a values_fn =
list(list)
Under 4.1.1 values_fn = list worked

prep_data: changed
rename_with(to_lower) to names() =
str_to_lower(names())