### PR TITLE
Omit fieldsize line from  vd_structure_match_expected

### DIFF
--- a/R/get_veda_dat.R
+++ b/R/get_veda_dat.R
@@ -319,7 +319,10 @@ vd_structure_match_expected <- function(filename, filetype){
     vd_reference_structure <- .vd_reference_structure[[1]]
     vd_header <- scan(filename, skip = 2, what = character(),  nmax = 35 )
     #check vd file structure matches reference structure
-    identical(vd_header, vd_reference_structure)
+    structure_match <- purrr::map2(vd_header, vd_reference_structure, ~identical(.x, .y))
+    #line 20 specifies the field size. This might differ depending on different versions of GAMS. So check if all other lines in structure match == TRUE
+    sum(unlist(structure_match)[-20]) ==
+      length(vd_reference_structure)-1
   }else{
 
     vd_reference_file <- .vd_reference_structure[[filetype]]


### PR DESCRIPTION
Fieldsize specification differs in different versions of GAMS.
The function vd_structure_match_expected has been altered to exclude the
field size line when checking for matches